### PR TITLE
remove unnecessary overload

### DIFF
--- a/src/main/matlab/+ala_laurila_lab/+rigs/AaltoPatchRigOneAmp.m
+++ b/src/main/matlab/+ala_laurila_lab/+rigs/AaltoPatchRigOneAmp.m
@@ -1,15 +1,6 @@
 classdef AaltoPatchRigOneAmp < ala_laurila_lab.rigs.AaltoPatchRig
 
     methods
-                
-        function prepareRigDescription(obj)
-            obj.addAmplifier();
-            obj.addProjector();
-            obj.addRigSwitches();
-            obj.addOscilloscopeTrigger();
-            obj.addFilterWheels();
-            obj.addTempratureController();
-        end
         
         function addAmplifier(obj)
             


### PR DESCRIPTION
This PR removes a function in the one amplifier configuration which was the same as the overloaded function in the base configuration. It will have no effect on functionality, except to resolve a bug with the multiphoton calibration protocol. In the future this overload could be reimplemented if there is a desired behavior difference between the configurations.